### PR TITLE
Added new method that correctly redirects user to blog.

### DIFF
--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -24,7 +24,7 @@
                     </div>
                     <div class="name">
                         <h1>{{profile.name}}</h1>
-                        <a :href="profile.blog">{{getBlog(profile.blog)}}</a>
+                        <a @click.prevent="goToBlog(profile.blog)" :href="profile.blog">{{getBlog(profile.blog)}}</a>
                     </div>
                 </div>
                 <div class="stats">
@@ -231,6 +231,12 @@ export default {
         a.includes(x) ? (a = a.replace(x, "")) : "";
       });
       return a;
+    },
+    // manually navigate to the blog
+    goToBlog: function(url) {
+      url.match(/https/) ? 
+        window.location.href = url : 
+        window.location.href = "http://www." + url;
     },
     //changes url from api.github.com to standard form
     cleanURL: function(u) {


### PR DESCRIPTION
Hi man, cool product you've got there.
So I was checking it out and I noticed a problem.
Clicking on a blog url doesn't redirect you to the blog if the blog is running on `http`, it only appends the url to the current href and since that path is not recognized by vue, It renders an empty page. 
This problem only persists with blogs running on `http`.
`https` websites work fine.
This pr contains a fix to the issue.
Hopefully my pr will be merged into this wonderful product.
Cheers!

ps: and hey get in touch, I'd love to work on something with you.